### PR TITLE
Disabled second UseErrorPage call. Fixes #12

### DIFF
--- a/src/ExtensionGallery/Startup.cs
+++ b/src/ExtensionGallery/Startup.cs
@@ -65,7 +65,7 @@ namespace ExtensionGallery
 				//app.UseErrorHandler("/Home/Error");
 			}
 
-			app.UseErrorPage(ErrorPageOptions.ShowAll);
+			// app.UseErrorPage(ErrorPageOptions.ShowAll);
 
 			// Add static files to the request pipeline.
 			//var options = new StaticFileOptions();


### PR DESCRIPTION
To stop information being leaked in production
