### PR TITLE
Catch missing folder on initial run

### DIFF
--- a/src/ExtensionGallery/Code/PackageHelper.cs
+++ b/src/ExtensionGallery/Code/PackageHelper.cs
@@ -36,6 +36,11 @@ namespace ExtensionGallery.Code
 		{
 			List<Package> packages = new List<Package>();
 
+            if(!Directory.Exists(_extensionRoot))
+            {
+                return packages.ToList();
+            }
+
 			foreach (string extension in Directory.EnumerateDirectories(_extensionRoot))
 			{
 				string json = Path.Combine(extension, "extension.json");

--- a/src/ExtensionGallery/Code/PackageHelper.cs
+++ b/src/ExtensionGallery/Code/PackageHelper.cs
@@ -36,10 +36,10 @@ namespace ExtensionGallery.Code
 		{
 			List<Package> packages = new List<Package>();
 
-            if(!Directory.Exists(_extensionRoot))
-            {
-                return packages.ToList();
-            }
+			if (!Directory.Exists(_extensionRoot))
+			{
+				return packages.ToList();
+			}
 
 			foreach (string extension in Directory.EnumerateDirectories(_extensionRoot))
 			{


### PR DESCRIPTION
Would crash on first run as extensions folder doesn't exist until an extension is uploaded
