### PR TITLE
Display the README.md from bitbucket repositories

### DIFF
--- a/src/ExtensionGallery/app/services/gallery.js
+++ b/src/ExtensionGallery/app/services/gallery.js
@@ -96,6 +96,9 @@
         }
 
         var url = package.Repo.replace("https://github.com", "https://raw.githubusercontent.com") + "master/README.md";
+        if (package.Repo.indexOf("bitbucket") > -1) {
+            url = package.Repo + "raw/tip/README.md";
+        }
 
         $http.get("http://markdownservice.azurewebsites.net/markdown.ashx?url=" + escape(url))
 			.success(function (data) {


### PR DESCRIPTION
Download and display the README.md file from extensions hosted on bitbucket.org.

See also [this related pull request](https://github.com/madskristensen/ExtensionScripts/pull/8)
