### PR TITLE
Changed link to the extension in the feed

### DIFF
--- a/src/ExtensionGallery/Code/FeedWriter.cs
+++ b/src/ExtensionGallery/Code/FeedWriter.cs
@@ -52,7 +52,7 @@ namespace ExtensionGallery.Code
 
 			writer.WriteStartElement("link");
 			writer.WriteAttributeString("rel", "alternate");
-			writer.WriteAttributeString("href", baseUrl + "/extensions/" + package.ID + "/extension.vsix");
+			writer.WriteAttributeString("href", baseUrl + "/extensions/" + package.ID);
 			writer.WriteEndElement(); // link
 
 			writer.WriteStartElement("summary");


### PR DESCRIPTION
When you click on a link to an extension in an RSS reader, it doesn't take you to the extension in the gallery, it immediately initiates a download.  I don't want to download extensions without visiting the extension in the gallery, reading about it, and even possibly visiting its source code repository.